### PR TITLE
Fix install update minitest on 2015

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,7 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = 'daptiv/windows2012r2_chef11'
+  config.vm.box = 'daptiv/windows2012r2_chef12'
   config.vm.communicator = :winrm
   config.vm.provision :chef_solo do |chef|
-    chef.add_recipe 'sqlce::default'
     chef.add_recipe 'visualstudio::default'
     chef.add_recipe 'visualstudio::install_update'
     chef.add_recipe 'visualstudio::install_vsto'
@@ -10,7 +9,7 @@ Vagrant.configure("2") do |config|
     chef.file_cache_path = 'c:/var/chef/cache' # Need leading drive letter
     chef.json = {
       'visualstudio' => {
-        'version' => '2012',
+        'version' => '2015',
         'edition' => 'professional',
         'source' => 'http://vagrantboxes.hq.daptiv.com/installs/cookbookresources',
         'preserve_extracted_files' => true

--- a/files/default/test/install_update_test.rb
+++ b/files/default/test/install_update_test.rb
@@ -9,7 +9,10 @@ class InstallUpdateSpec < MiniTest::Chef::Spec
 
       it 'installs Visual Studio update' do
         each_version_edition(node) do |version, _|
-          node['visualstudio'][version]['update']['package_name'].must_be_installed
+          # not all versions support an update
+          if node['visualstudio'][version]['update']
+            node['visualstudio'][version]['update']['package_name'].must_be_installed
+          end
         end
       end
     end


### PR DESCRIPTION
@heathsnow This allows us to keep the update recipe in the runlist along with the minitests with Visual Studio 2015 which doesn't have an update.