### PR TITLE
allow more time for tools install on slower nodes

### DIFF
--- a/recipes/install_vsto.rb
+++ b/recipes/install_vsto.rb
@@ -40,6 +40,7 @@ versions.each do |version|
       checksum node['visualstudio']['2012']['vsto']['checksum']
       installer_type :custom
       options "/Q /norestart /noweb /Log \"#{install_log_path}\""
+      timeout 1800
       action :install
     end
   else


### PR DESCRIPTION
- [ ] @sneal 

Mitigate the following error:

```ruby
==> default: ================================================================================
==> default: Error executing action `install` on resource 'windows_package[Microsoft Office Developer Tools for Visual Studio 2012 ENU]'
==> default: ================================================================================
==> default: 
==> default: Mixlib::ShellOut::CommandTimeout
==> default: --------------------------------
==> default: command timed out:
==> default: ---- Begin output of start "" /wait "c:\var\chef\cache\officetools_bundle.exe" /Q /norestart /noweb /Log "C:\Program Files (x86)\Microsoft Visual Studio 11.0\vstoinstall.log" & exit %%ERRORLEVEL%% ----
==> default: STDOUT: 
==> default: STDERR: 
==> default: ---- End output of start "" /wait "c:\var\chef\cache\officetools_bundle.exe" /Q /norestart /noweb /Log "C:\Program Files (x86)\Microsoft Visual Studio 11.0\vstoinstall.log" & exit %%ERRORLEVEL%% ----
```