### PR TITLE
Use /q for VS 2010 by default instead of unattend template

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you _really_ want to install VS 2015 on Windows Server 2012R2 over naked WinR
   </tr>
   <tr>
     <td><code>['visualstudio']['2010']['professional']['config_file']</code></td>
-    <td>Boolean</td>
+    <td>String</td>
     <td>The name of the VS 2010 unattend.ini template to use.</td>
     <td></td>
   </tr>
@@ -127,7 +127,7 @@ node.override['visualstudio']['2013']['professional']['checksum'] = 'c4930bb8345
 node.override['visualstudio']['2013']['professional']['filename'] = 'My_vs2013.iso'
 ```
 
-Unlike newer versions of VisualStudio which use an AdminDeployment.xml file, VS 2010 uses an unattend.ini file. This cookbook includes a working default unattend.ini template which you may optionally override. The use of a template instead of a static file is required due to relative paths inside the file.
+Unlike newer versions of VisualStudio which use an AdminDeployment.xml file, VS 2010 uses an unattend.ini file, which, among other things, is OS-specific. By default, this cookbook uses VS 2010's `/q` option, which works for all Windows versions and specifies a default installation. To customize the installation, you may specify an unattend.ini template instead. The use of a template instead of a static file is required due to relative paths inside the file. This cookbook includes an unattend.ini template sample.
 
 # Recipes
 
@@ -135,7 +135,7 @@ Unlike newer versions of VisualStudio which use an AdminDeployment.xml file, VS 
 Ensures all VisualStudio prereqs are installed first and then only runs the install recipe if they are met. You should add this recipe to your run list.
 
 ## install
-Installs VisualStudio using the included AdminDeployment.xml or unattend.ini. Included by the default recipe.
+Installs VisualStudio using the included AdminDeployment.xml or default silent install. Included by the default recipe.
 
 ## nuget
 Configures the enable_nuget_package_restore environment variable. Included by the default recipe.

--- a/attributes/vs2010.rb
+++ b/attributes/vs2010.rb
@@ -31,7 +31,7 @@ default['visualstudio']['2010']['professional']['package_name'] =
 default['visualstudio']['2010']['professional']['checksum'] =
   'bdfba5df0bd72cffdb398fe885d9e36d052617647c0ae4fd0579a8fc785c95ba'
 default['visualstudio']['2010']['professional']['installer_file'] = File.join('setup', 'setup.exe')
-default['visualstudio']['2010']['professional']['config_file'] = 'unattend.ini'
+default['visualstudio']['2010']['professional']['config_file'] = nil
 
 # VS 2010 SP1
 default['visualstudio']['2010']['update']['filename'] = 'VS2010SP1dvd1.iso'

--- a/providers/edition.rb
+++ b/providers/edition.rb
@@ -84,6 +84,14 @@ def prepare_vs_options
 end
 
 def prepare_vs2010_options
+  if new_resource.configure_basename.nil?
+    '/q'
+  else
+    "/unattendfile \"#{configure_vs2010_unattend_file}\""
+  end
+end
+
+def configure_vs2010_unattend_file
   config_path = win_friendly_path(::File.join(extracted_iso_dir, new_resource.configure_basename))
 
   template "#{config_path}.tmp" do
@@ -99,8 +107,7 @@ def prepare_vs2010_options
     )
   end
 
-  setup_options = "/unattendfile \"#{config_path}\""
-  setup_options
+  config_path
 end
 
 def install_log_file


### PR DESCRIPTION
VS 2010's unattend.ini files are OS-specific, so a given file will only work on the version of Windows
on which it was generated. In order to support installing VS 2010 on any OS out of the box, I have
changed this cookbook to use `/q` by default instead of `/unattend`. The `/q` option specifies a
silent installation with default options.

You may still specify an `unattend.ini` file if you wish to customize the installation.

This fixes issue #36.

I added unit tests to verify the behavior with and without specifying a custom VS 2010 unattend file. I also tested this in a local vagrant setup which installs VS 2010 on Windows 2012r2 and Windows 10. On 2012r2, I tested both with and without specifying a custom unattend.ini file.